### PR TITLE
fix: Add .editorconfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+# EditorConfig helps maintain consistent coding styles across different editors
+# https://editorconfig.org
+
+root = true
+
+# Default settings for all files
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# TypeScript and JavaScript files
+[*.{ts,tsx,js,jsx,mjs,cjs}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# Makefile requires tabs
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

- **YAML 檔案** - 2 空格縮排
- **Markdown 檔案** - 保留尾隨空白（避免破壞 Markdown 格式中的強制換行）
- **Makefile** - 使用 tab 縮排（Makefile 的必要設定）

所有設定都與現有的 `.prettierrc` 保持一致，確保跨編輯器的程式碼風格統一。

Closes #2

---
🤖 *Generated by Haunted AI*